### PR TITLE
Update instruction on how to insert pre-rendered HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Enlive-backed Hiccup implementation (clj-only)
 - Fragments (`[:<> ...]`)
 - Components (`[my-fn ...]`)
 - Style maps (`[:div {:style {:color "blue"}}]`)
-- Insert pre-rendered HTML with `[::hiccup/raw "your html"]`
+- Insert pre-rendered HTML with `[::hiccup/unsafe-html "your html"]`
 
 This makes it behave closer to how Hiccup works in Reagent, reducing cognitive
 overhead when doing cross-platform development.


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->

The README demonstrates how to insert pre-rendered HTML using the keyword `::hiccup/raw`, which only works in an older revision of the code. The newest version supports the keyword `::hiccup/unsafe-html` instead, so I've updated the README to use that.
