### PR TITLE
Fix rendering of boolean attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Correctly handle boolean attributes (false values are removed rather than being set to "false")
+
 ## Changed
 
 # 0.0.4 (2021-10-28 / 8c0198a)

--- a/src/lambdaisland/hiccup.clj
+++ b/src/lambdaisland/hiccup.clj
@@ -38,7 +38,10 @@
               classes (keep (fn [^String seg]
                               (when (= \. (.charAt seg 0)) (subs seg 1)))
                             segments)
-              node {:tag (keyword tag-name) :attrs (if (attr-map? m) m {})
+              node {:tag (keyword tag-name)
+                    :attrs (if (attr-map? m)
+                             (into {} (filter val m))
+                             {})
                     :content (enlive/flatmap #(nodify % opts) (if (attr-map? m) ms more))}
               node (if id (assoc-in node [:attrs :id] id) node)
               node (if (seq classes)


### PR DESCRIPTION
When boolean attributes are false they should
be removed as the presence of attribute=false
is interpreted as the attribute being set.

There is a PR against enlive that does exactly the same thing but it has never been merged: https://github.com/cgrand/enlive/pull/107

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
