### PR TITLE
Convert attributes to camelCase, with some exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@
 
 ## Changed
 
-- Convert attributes to camelCase, except strings, data-*, aria-* and certain html and svg attributes that are expected to be kebab-case
+- Convert multi-word attributes to match Reagent + React's behaviour.
+
+  data-, aria-, and hx- attributes remain kebab-case.
+  html and svg attributes that are kebab-case in those specs, are converted to kebab-case
+
+  BREAKING in some cases:
+
+    Previously:
+    :tab-index -> "tab-index"
+    "fontStyle" -> "fontStyle"
+    :fontStyle -> "fontStyle"
+
+    Now:
+    :tab-index -> "tabIndex"
+    "fontStyle" -> "font-style"
+    :fontStyle -> "font-style"
 
 # 0.0.15 (2023-03-20 / c0a2d53)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ## Changed
 
-# 0.0.!! (2023-05-08 / ???)
-
 - Convert attributes to camelCase, except strings, data-*, aria-* and certain html and svg attributes that are expected to be kebab-case
 
 # 0.0.15 (2023-03-20 / c0a2d53)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## Changed
 
+# 0.0.!! (2023-05-08 / ???)
+
+- Convert attributes to camelCase, except data-*, aria-* and certain html and svg attributes that are expected to be kebab-case
+
 # 0.0.15 (2023-03-20 / c0a2d53)
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 # 0.0.!! (2023-05-08 / ???)
 
-- Convert attributes to camelCase, except data-*, aria-* and certain html and svg attributes that are expected to be kebab-case
+- Convert attributes to camelCase, except strings, data-*, aria-* and certain html and svg attributes that are expected to be kebab-case
 
 # 0.0.15 (2023-03-20 / c0a2d53)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hiccup
 
 <!-- badges -->
-[![CircleCI](https://circleci.com/gh/lambdaisland/hiccup.svg?style=svg)](https://circleci.com/gh/lambdaisland/hiccup) [![cljdoc badge](https://cljdoc.org/badge/com.lambdaisland/hiccup)](https://cljdoc.org/d/com.lambdaisland/hiccup) [![Clojars Project](https://img.shields.io/clojars/v/com.lambdaisland/hiccup.svg)](https://clojars.org/com.lambdaisland/hiccup) 
+[![CircleCI](https://circleci.com/gh/lambdaisland/hiccup.svg?style=svg)](https://circleci.com/gh/lambdaisland/hiccup) [![cljdoc badge](https://cljdoc.org/badge/com.lambdaisland/hiccup)](https://cljdoc.org/d/com.lambdaisland/hiccup) [![Clojars Project](https://img.shields.io/clojars/v/com.lambdaisland/hiccup.svg)](https://clojars.org/com.lambdaisland/hiccup)
 <!-- /badges -->
 
 Enlive-backed Hiccup implementation (clj-only)
@@ -13,6 +13,7 @@ Enlive-backed Hiccup implementation (clj-only)
 - Components (`[my-fn ...]`)
 - Style maps (`[:div {:style {:color "blue"}}]`)
 - Insert pre-rendered HTML with `[::hiccup/unsafe-html "your html"]`
+- Convert attributes to camelCase, except those HTML + SVG expects to remain kebab-case (`data-*, aria-*, accept-charset...`)
 
 This makes it behave closer to how Hiccup works in Reagent, reducing cognitive
 overhead when doing cross-platform development.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ Enlive-backed Hiccup implementation (clj-only)
 - Components (`[my-fn ...]`)
 - Style maps (`[:div {:style {:color "blue"}}]`)
 - Insert pre-rendered HTML with `[::hiccup/unsafe-html "your html"]`
-- Convert attributes to camelCase, except `"strings"` and those HTML + SVG expects to remain kebab-case (`data-*, aria-*, accept-charset...`)
-
-This makes it behave closer to how Hiccup works in Reagent, reducing cognitive
-overhead when doing cross-platform development.
+- Convert multi-word attributes to the appropriate case, matching Reagent + React's behaviour (`:tab-index -> "tabIndex"`; `"fontStyle" -> "font-style"`); you should be able to use `:kebab-case` keywords and get what you expect
 
 <!-- installation -->
 ## Installation

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Enlive-backed Hiccup implementation (clj-only)
 - Components (`[my-fn ...]`)
 - Style maps (`[:div {:style {:color "blue"}}]`)
 - Insert pre-rendered HTML with `[::hiccup/unsafe-html "your html"]`
-- Convert attributes to camelCase, except those HTML + SVG expects to remain kebab-case (`data-*, aria-*, accept-charset...`)
+- Convert attributes to camelCase, except `"strings"` and those HTML + SVG expects to remain kebab-case (`data-*, aria-*, accept-charset...`)
 
 This makes it behave closer to how Hiccup works in Reagent, reducing cognitive
 overhead when doing cross-platform development.

--- a/src/lambdaisland/hiccup.clj
+++ b/src/lambdaisland/hiccup.clj
@@ -76,9 +76,10 @@
                            (fn [attrs]
                              (->> attrs
                                   (map (fn [[k v]]
-                                         [(if (keep-kebab-case? k)
-                                            k
-                                            (camel-case k))
+                                         [(cond
+                                            (string? k) k
+                                            (keep-kebab-case? k) k
+                                            :else (camel-case k))
                                           v]))
                                   (into {}))))
               node (if id (assoc-in node [:attrs :id] id) node)

--- a/src/lambdaisland/hiccup.clj
+++ b/src/lambdaisland/hiccup.clj
@@ -63,8 +63,8 @@
 (defn convert-attribute-react-logic
   [attr-str]
   (let [kebab-str (camel->kebab attr-str)]
-    ;; not use kebab-in-html? here b/c
-    ;; React does not convert ariaFoo to aria-foo
+    ;; not using kebab-in-html? here because
+    ;; React does not convert dataFoo to data-foo
     ;; but does convert fontStretch to font-stretch
     (if (kebab-case-tags kebab-str)
       kebab-str

--- a/test/lambdaisland/hiccup_test.clj
+++ b/test/lambdaisland/hiccup_test.clj
@@ -44,4 +44,7 @@
            "<div font-family=\"Arial\"></div>")))
   (testing "keeps string attributes as is"
     (is (= (hiccup/render [:div {"foo-bar" "baz"}] {:doctype? false})
-           "<div foo-bar=\"baz\"></div>"))))
+           "<div foo-bar=\"baz\"></div>")))
+  (testing "camelCase attributes remain as is"
+    (is (= (hiccup/render [:div {:camelCase "foo"}] {:doctype? false})
+           "<div camelCase=\"foo\"></div>"))))

--- a/test/lambdaisland/hiccup_test.clj
+++ b/test/lambdaisland/hiccup_test.clj
@@ -1,5 +1,5 @@
 
-(ns lambdaisland.hiccup-test 
+(ns lambdaisland.hiccup-test
   (:require [clojure.test :refer [deftest testing is]]
             [lambdaisland.hiccup :as hiccup]))
 
@@ -7,11 +7,11 @@
   [:p contents])
 
 (defn test-fragment-component [contents]
-  [:<> 
+  [:<>
    [:p contents]
    [:p contents]])
 
-(deftest render-test 
+(deftest render-test
   (testing "simple tag"
     (is (= (hiccup/render [:p] {:doctype? false})
          "<p></p>")))
@@ -22,10 +22,10 @@
     (is (= (hiccup/render [:div {:style {:color "blue"}} [:p]] {:doctype? false})
            "<div style=\"color: blue;\"><p></p></div>")))
   (testing "simple component"
-    (is (= (hiccup/render [my-test-component "hello"] {:doctype? false}) 
+    (is (= (hiccup/render [my-test-component "hello"] {:doctype? false})
            "<p>hello</p>")))
   (testing "simple component with fragment"
-    (is (= (hiccup/render [:div [test-fragment-component "hello"]] {:doctype? false}) 
+    (is (= (hiccup/render [:div [test-fragment-component "hello"]] {:doctype? false})
            "<div><p>hello</p><p>hello</p></div>")))
   (testing "pre-rendered HTML"
     (is (= (hiccup/render [::hiccup/unsafe-html "<body><main><article><p></p></article></main></body>"] {:doctype? false})
@@ -41,4 +41,7 @@
            "<div data-foo=\"bar\"></div>")))
   (testing "keeps certain http and svg attributes as kebab-case"
     (is (= (hiccup/render [:div {:font-family "Arial"}] {:doctype? false})
-           "<div font-family=\"Arial\"></div>"))))
+           "<div font-family=\"Arial\"></div>")))
+  (testing "keeps string attributes as is"
+    (is (= (hiccup/render [:div {"foo-bar" "baz"}] {:doctype? false})
+           "<div foo-bar=\"baz\"></div>"))))

--- a/test/lambdaisland/hiccup_test.clj
+++ b/test/lambdaisland/hiccup_test.clj
@@ -32,4 +32,13 @@
            "<body><main><article><p></p></article></main></body>")))
   (testing "autoescaping"
     (is (= (hiccup/render [:div "<p></p>"] {:doctype? false})
-           "<div>&lt;p&gt;&lt;/p&gt;</div>"))))
+           "<div>&lt;p&gt;&lt;/p&gt;</div>")))
+  (testing "camelCases attributes"
+    (is (= (hiccup/render [:div {:foo-bar "baz"}] {:doctype? false})
+           "<div fooBar=\"baz\"></div>")))
+  (testing "keeps data-* attributes as kebab-case"
+    (is (= (hiccup/render [:div {:data-foo "bar"}] {:doctype? false})
+           "<div data-foo=\"bar\"></div>")))
+  (testing "keeps certain http and svg attributes as kebab-case"
+    (is (= (hiccup/render [:div {:font-family "Arial"}] {:doctype? false})
+           "<div font-family=\"Arial\"></div>"))))


### PR DESCRIPTION
When using Reagent+React, attributes are camelCased, ex. `:foo-bar "baz"` -> `fooBar="baz"`.

...except for:
  - `data-*` and `aria-*` attributes ([reagent src](https://github.com/reagent-project/reagent/blob/a14faba55e373000f8f93edfcfce0d1222f7e71a/src/reagent/impl/util.cljs#L26))
  - strings ([reagent src](https://github.com/reagent-project/reagent/blob/a14faba55e373000f8f93edfcfce0d1222f7e71a/src/reagent/impl/util.cljs#L34))
  - some HTML and SVG attributes (`accept-charset`, `accent-height`, and [many others](https://github.com/preactjs/preact-compat/issues/222#issuecomment-251555615); React expects them camelCased, but converts to kebab-case when rendering.)

To enable better re-use of the same component between Reagent and on the backend, this PR implements converting from kebab-case to camelCase by default, except for the exceptions mentioned above.

Note: this does change existing behaviour, so it is "BREAKING".

Also: `CHANGELOG.md` has a placeholder message, but needs to be updated before merging into master.
